### PR TITLE
fix: typescript error on values in Form cp and data-attr on Input cp

### DIFF
--- a/src/components/Form/Form.Style.css
+++ b/src/components/Form/Form.Style.css
@@ -1,10 +1,11 @@
 form {
-  max-width: 31.25rem;
-  min-width: 18.75rem;
+  max-width: 500px;
+  min-width: 300px;
   width: 100%;
-
-  padding: 0.5rem;
   
+
+  padding: 8px;
+
   border: 1px solid salmon;
-  border-radius: 0.625rem;
+  border-radius: 10px;
 }

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -17,7 +17,7 @@ const Form = () => {
     {
       id: 1,
       type: 'text',
-      name: 'firstName',
+      name: 'firstName' as const,
       placeholder: 'Insira seu nome',
       pattern: '^[A-Za-z]{3,}',
       required: true,
@@ -74,7 +74,7 @@ const Form = () => {
     e.preventDefault()
     console.log(values)
     alert('Cadastro Efetuado')
-    clear()
+    // clear()
   }
 
   // Clear Inputs
@@ -95,7 +95,7 @@ const Form = () => {
         <Input
           key={input.id}
           {...input}
-          value={values[input.name]}
+          value={values[input.name as keyof typeof values]}
           onChange={handleOnChangeInput}
         />
       ))}

--- a/src/components/Form/input/Input.Style.css
+++ b/src/components/Form/input/Input.Style.css
@@ -15,7 +15,12 @@
   font-size: 0.875rem;
 }
 
-.inpt__field:invalid[focus='true'] ~ .error__message {
+.inpt__field:invalid[data-focus='true'] {
+  border: 1px solid crimson;
+  border-radius: 0.625rem;
+}
+
+.inpt__field:invalid[data-focus='true'] ~ .error__message {
   display: block;
 }
 

--- a/src/components/Form/input/Input.tsx
+++ b/src/components/Form/input/Input.tsx
@@ -15,9 +15,10 @@ interface IInput {
 const Input = (props: IInput) => {
   const [focus, setFocus] = useState(false)
 
-  const handleFocusInput = (e: InputHTMLAttributes<HTMLInputElement>) => {
-    setFocus(true)
+  const handleFocusInput = () => {
+    setFocus(!focus)
   }
+
   return (
     <>
       <div className='input__container'>
@@ -30,8 +31,11 @@ const Input = (props: IInput) => {
           onChange={props.onChange}
           required={props.required}
           pattern={props.pattern}
+          data-focus={focus.toString()}
           onBlur={handleFocusInput}
-          focus={focus.toString()}
+          onFocus={() =>
+            props.name === 'confirmPassword' && setFocus(!focus)
+          }
         />
         <div className='bottom__border'></div>
         <span className='error__message'>{props.error_message}</span>


### PR DESCRIPTION
### **Fix** 

### Typescript error on values 

```value={values[input.name]}``` => This works but Typescript says Element has an any type because of type string

### Solution: 

```value={values[input.name as keyof typeof values]}``` => declare as keyof and typeof values state